### PR TITLE
adding code block to dynamically change tip badge based on theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ you can use these additional badges to give your makrdown more structure and sta
 > ![badge-tip][badge-tip]<br>
 > Tip
 
+Use the following code to dynamically change the `Tip` icon based on user theme:
+```
+<picture>
+ <source media="(prefers-color-scheme: dark)" srcset="https://github.com/Mqxx/GitHub-Markdown/blob/main/blockquotes/badge/dark-theme/tip.svg">
+ <img alt="Shows an illustrated sun in light color mode and a moon with stars in dark color mode." src="https://github.com/Mqxx/GitHub-Markdown/blob/main/blockquotes/badge/light-theme/tip.svg">
+</picture>
+```
+
 <br>
 
 #### Issue Badge


### PR DESCRIPTION
Hey, I found out that you can change an image based on dark/light mode in a markdown file on GitHub so I think this would be great for the `Tip` badge. I'm wanting to add this to your repo!

I found out about this [Stack Overflow](https://stackoverflow.com/questions/66247653/get-the-user-selected-color-theme-in-github-readme)